### PR TITLE
Support for other types

### DIFF
--- a/enum-map/src/internal.rs
+++ b/enum-map/src/internal.rs
@@ -65,6 +65,26 @@ impl<T> EnumArray<T> for bool {
     type Array = [T; Self::LENGTH];
 }
 
+impl Enum for () {
+    const LENGTH: usize = 1;
+
+    #[inline]
+    fn from_usize(value: usize) -> Self {
+        match value {
+            0 => (),
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    fn into_usize(self) -> usize {
+        0
+    }
+}
+
+impl<T> EnumArray<T> for () {
+    type Array = [T; Self::LENGTH];
+}
+
 impl Enum for u8 {
     const LENGTH: usize = 256;
 

--- a/enum-map/src/internal.rs
+++ b/enum-map/src/internal.rs
@@ -118,3 +118,29 @@ impl Enum for Infallible {
 impl<T> EnumArray<T> for Infallible {
     type Array = [T; Self::LENGTH];
 }
+
+impl Enum for core::cmp::Ordering {
+    const LENGTH: usize = 3;
+
+    #[inline]
+    fn from_usize(value: usize) -> Self {
+        match value {
+            0 => core::cmp::Ordering::Less,
+            1 => core::cmp::Ordering::Equal,
+            2 => core::cmp::Ordering::Greater,
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    fn into_usize(self) -> usize {
+        match self {
+            core::cmp::Ordering::Less => 0,
+            core::cmp::Ordering::Equal => 1,
+            core::cmp::Ordering::Greater => 2,
+        }
+    }
+}
+
+impl<T> EnumArray<T> for core::cmp::Ordering {
+    type Array = [T; Self::LENGTH];
+}


### PR DESCRIPTION
Hi, I'm the author of https://docs.rs/plain_enum/latest/plain_enum/, but I'm thinking about adopting `enum-map`, as it seems to have more traction in the community.

However, there are some missing bits that I'd like to address.

This PR adds support for the unit type and for `Ordering`, which I use in my projects.