### PR TITLE
Fix clippy lints

### DIFF
--- a/enum-map/src/lib.rs
+++ b/enum-map/src/lib.rs
@@ -300,6 +300,7 @@ impl<K: EnumArray<V>, V> EnumMap<K, V> {
 
     /// Returns number of elements in enum map.
     #[inline]
+    #[allow(clippy::unused_self)]
     pub const fn len(&self) -> usize {
         K::Array::LENGTH
     }

--- a/enum-map/tests/serde.rs
+++ b/enum-map/tests/serde.rs
@@ -58,7 +58,7 @@ fn invalid_compact_deserialization() {
 fn too_short_compact_deserialization() {
     assert_de_tokens_error::<Compact<EnumMap<bool, bool>>>(
         &[Token::Seq { len: None }, Token::Bool(true), Token::SeqEnd],
-        &"invalid length 1, expected a sequence with as many elements as there are variants",
+        "invalid length 1, expected a sequence with as many elements as there are variants",
     );
 }
 

--- a/enum-map/tests/test.rs
+++ b/enum-map/tests/test.rs
@@ -463,7 +463,7 @@ fn assert_enum_map_does_not_copy_sync_send_dependency_of_keys() {
     assert_sync_send(map.iter());
     assert_sync_send(map.iter_mut());
     assert_sync_send(map.into_iter());
-    assert_eq!(map[X::A(PhantomData)], true);
+    assert!(map[X::A(PhantomData)]);
 }
 
 #[test]


### PR DESCRIPTION
There's a few things that got caught by `clippy::pedantic`, this is a small PR to eliminate them.

1. `enum-map/src/lib.rs#303`: Add `#[allow(clippy::unused_self)]`

The self parameter is unused, but the API lines up more closely with other standard data structures to take `&self` so it makes sense to tell clippy to allow this.

2. `enum-map/tests/serde.rs#61`: Remove double-reference to string literal

This reference was immediately dereferenced by the compiler, so removing it improves code clarity.

3. `enum-map/tests/test.rs#466`: Change `assert_eq!(val, true)` to `assert!(val)`

Since there was an equality check against a boolean, it can be expressed instead as `assert!`.