### PR TITLE
Replace EnumArray by generic associated type

### DIFF
--- a/enum-map-derive/src/derive_enum.rs
+++ b/enum-map-derive/src/derive_enum.rs
@@ -38,6 +38,7 @@ impl EnumGenerator {
             #[automatically_derived]
             impl ::enum_map::Enum for #name {
                 const LENGTH: ::enum_map::usize = #length;
+                type Array<V> = [V; Self::LENGTH];
 
                 #[inline]
                 fn from_usize(value: ::enum_map::usize) -> Self {
@@ -52,11 +53,6 @@ impl EnumGenerator {
                         #into_usize_arms
                     }
                 }
-            }
-
-            #[automatically_derived]
-            impl<V> ::enum_map::EnumArray<V> for #name {
-                type Array = [V; #length];
             }
         }
     }

--- a/enum-map-derive/src/derive_struct.rs
+++ b/enum-map-derive/src/derive_struct.rs
@@ -103,6 +103,7 @@ impl StructGenerator {
             #[automatically_derived]
             impl ::enum_map::Enum for #name {
                 const LENGTH: ::enum_map::usize = #length;
+                type Array<V> = [V; Self::LENGTH];
 
                 #[inline]
                 fn from_usize(value: ::enum_map::usize) -> Self {
@@ -113,11 +114,6 @@ impl StructGenerator {
                 fn into_usize(self) -> ::enum_map::usize {
                     #into_usize
                 }
-            }
-
-            #[automatically_derived]
-            impl<V> ::enum_map::EnumArray<V> for #name {
-                type Array = [V; #length];
             }
         }
     }

--- a/enum-map/src/arbitrary.rs
+++ b/enum-map/src/arbitrary.rs
@@ -1,8 +1,8 @@
-use crate::{enum_map, EnumArray, EnumMap};
+use crate::{enum_map, Enum, EnumMap};
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 /// Requires crate feature `"arbitrary"`
-impl<'a, K: EnumArray<V>, V: Arbitrary<'a>> Arbitrary<'a> for EnumMap<K, V> {
+impl<'a, K: Enum, V: Arbitrary<'a>> Arbitrary<'a> for EnumMap<K, V> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<EnumMap<K, V>> {
         Ok(enum_map! {
             _ => Arbitrary::arbitrary(u)?,

--- a/enum-map/src/enum_map_impls.rs
+++ b/enum-map/src/enum_map_impls.rs
@@ -1,16 +1,16 @@
-use crate::{enum_map, EnumArray, EnumMap};
+use crate::{enum_map, Enum, EnumMap};
 use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Extend, FromIterator};
 use core::ops::{Index, IndexMut};
 
-impl<K: EnumArray<V> + Debug, V: Debug> Debug for EnumMap<K, V> {
+impl<K: Enum + Debug, V: Debug> Debug for EnumMap<K, V> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_map().entries(self).finish()
     }
 }
 
-impl<K: EnumArray<V>, V> Extend<(K, V)> for EnumMap<K, V> {
+impl<K: Enum, V> Extend<(K, V)> for EnumMap<K, V> {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (key, value) in iter {
             self[key] = value;
@@ -20,7 +20,7 @@ impl<K: EnumArray<V>, V> Extend<(K, V)> for EnumMap<K, V> {
 
 impl<'a, K, V> Extend<(&'a K, &'a V)> for EnumMap<K, V>
 where
-    K: EnumArray<V> + Copy,
+    K: Enum + Copy,
     V: Copy,
 {
     fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
@@ -31,7 +31,7 @@ where
 impl<K, V> FromIterator<(K, V)> for EnumMap<K, V>
 where
     Self: Default,
-    K: EnumArray<V>,
+    K: Enum,
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut map = EnumMap::default();
@@ -40,7 +40,7 @@ where
     }
 }
 
-impl<K: EnumArray<V>, V> Index<K> for EnumMap<K, V> {
+impl<K: Enum, V> Index<K> for EnumMap<K, V> {
     type Output = V;
 
     #[inline]
@@ -49,7 +49,7 @@ impl<K: EnumArray<V>, V> Index<K> for EnumMap<K, V> {
     }
 }
 
-impl<K: EnumArray<V>, V> IndexMut<K> for EnumMap<K, V> {
+impl<K: Enum, V> IndexMut<K> for EnumMap<K, V> {
     #[inline]
     fn index_mut(&mut self, key: K) -> &mut V {
         &mut self.as_mut_slice()[key.into_usize()]
@@ -58,9 +58,9 @@ impl<K: EnumArray<V>, V> IndexMut<K> for EnumMap<K, V> {
 
 // Implementations provided by derive attribute are too specific, and put requirements on K.
 // This is caused by rust-lang/rust#26925.
-impl<K: EnumArray<V>, V> Clone for EnumMap<K, V>
+impl<K: Enum, V> Clone for EnumMap<K, V>
 where
-    K::Array: Clone,
+    K::Array<V>: Clone,
 {
     #[inline]
     fn clone(&self) -> Self {
@@ -70,25 +70,25 @@ where
     }
 }
 
-impl<K: EnumArray<V>, V> Copy for EnumMap<K, V> where K::Array: Copy {}
+impl<K: Enum, V> Copy for EnumMap<K, V> where K::Array<V>: Copy {}
 
-impl<K: EnumArray<V>, V: PartialEq> PartialEq for EnumMap<K, V> {
+impl<K: Enum, V: PartialEq> PartialEq for EnumMap<K, V> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
-impl<K: EnumArray<V>, V: Eq> Eq for EnumMap<K, V> {}
+impl<K: Enum, V: Eq> Eq for EnumMap<K, V> {}
 
-impl<K: EnumArray<V>, V: Hash> Hash for EnumMap<K, V> {
+impl<K: Enum, V: Hash> Hash for EnumMap<K, V> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_slice().hash(state);
     }
 }
 
-impl<K: EnumArray<V>, V: Default> Default for EnumMap<K, V> {
+impl<K: Enum, V: Default> Default for EnumMap<K, V> {
     #[inline]
     fn default() -> Self {
         enum_map! { _ => V::default() }

--- a/enum-map/src/internal.rs
+++ b/enum-map/src/internal.rs
@@ -11,21 +11,13 @@ use core::convert::Infallible;
 pub trait Enum: Sized {
     /// Length of the enum.
     const LENGTH: usize;
+    /// Representation of an enum map for type `V`.
+    type Array<V>: Array<V>;
 
     /// Takes an usize, and returns an element matching `into_usize` function.
     fn from_usize(value: usize) -> Self;
     /// Returns an unique identifier for a value within range of `0..Array::LENGTH`.
     fn into_usize(self) -> usize;
-}
-
-/// Trait associating enum with an array.
-///
-/// This exists due to limitations of Rust compiler that prevent arrays from using
-/// associated constants in structures. The array length must match `LENGTH` of an
-/// `Enum`.
-pub trait EnumArray<V>: Enum {
-    /// Representation of an enum map for type `V`.
-    type Array: Array<V>;
 }
 
 /// Array for enum-map storage.
@@ -47,6 +39,7 @@ unsafe impl<V, const N: usize> Array<V> for [V; N] {
 
 impl Enum for bool {
     const LENGTH: usize = 2;
+    type Array<T> = [T; Self::LENGTH];
 
     #[inline]
     fn from_usize(value: usize) -> Self {
@@ -62,12 +55,9 @@ impl Enum for bool {
     }
 }
 
-impl<T> EnumArray<T> for bool {
-    type Array = [T; Self::LENGTH];
-}
-
 impl Enum for () {
     const LENGTH: usize = 1;
+    type Array<T> = [T; Self::LENGTH];
 
     #[inline]
     fn from_usize(value: usize) -> Self {
@@ -82,12 +72,9 @@ impl Enum for () {
     }
 }
 
-impl<T> EnumArray<T> for () {
-    type Array = [T; Self::LENGTH];
-}
-
 impl Enum for u8 {
     const LENGTH: usize = 256;
+    type Array<T> = [T; Self::LENGTH];
 
     #[inline]
     fn from_usize(value: usize) -> Self {
@@ -99,12 +86,9 @@ impl Enum for u8 {
     }
 }
 
-impl<T> EnumArray<T> for u8 {
-    type Array = [T; Self::LENGTH];
-}
-
 impl Enum for Infallible {
     const LENGTH: usize = 0;
+    type Array<T> = [T; Self::LENGTH];
 
     #[inline]
     fn from_usize(_: usize) -> Self {
@@ -116,12 +100,9 @@ impl Enum for Infallible {
     }
 }
 
-impl<T> EnumArray<T> for Infallible {
-    type Array = [T; Self::LENGTH];
-}
-
 impl Enum for Ordering {
     const LENGTH: usize = 3;
+    type Array<T> = [T; Self::LENGTH];
 
     #[inline]
     fn from_usize(value: usize) -> Self {
@@ -140,8 +121,4 @@ impl Enum for Ordering {
             Ordering::Greater => 2,
         }
     }
-}
-
-impl<T> EnumArray<T> for Ordering {
-    type Array = [T; Self::LENGTH];
 }

--- a/enum-map/src/iter.rs
+++ b/enum-map/src/iter.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use crate::{EnumArray, EnumMap};
+use crate::{Enum, EnumMap};
 use core::iter::{Enumerate, FusedIterator};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
@@ -40,7 +40,7 @@ pub struct Iter<'a, K, V: 'a> {
     iterator: Enumerate<slice::Iter<'a, V>>,
 }
 
-impl<'a, K: EnumArray<V>, V> Clone for Iter<'a, K, V> {
+impl<'a, K: Enum, V> Clone for Iter<'a, K, V> {
     fn clone(&self) -> Self {
         Iter {
             _phantom: PhantomData,
@@ -49,7 +49,7 @@ impl<'a, K: EnumArray<V>, V> Clone for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K: EnumArray<V>, V> Iterator for Iter<'a, K, V> {
+impl<'a, K: Enum, V> Iterator for Iter<'a, K, V> {
     type Item = (K, &'a V);
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -73,7 +73,7 @@ impl<'a, K: EnumArray<V>, V> Iterator for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K: EnumArray<V>, V> DoubleEndedIterator for Iter<'a, K, V> {
+impl<'a, K: Enum, V> DoubleEndedIterator for Iter<'a, K, V> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iterator
@@ -82,11 +82,11 @@ impl<'a, K: EnumArray<V>, V> DoubleEndedIterator for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K: EnumArray<V>, V> ExactSizeIterator for Iter<'a, K, V> {}
+impl<'a, K: Enum, V> ExactSizeIterator for Iter<'a, K, V> {}
 
-impl<'a, K: EnumArray<V>, V> FusedIterator for Iter<'a, K, V> {}
+impl<'a, K: Enum, V> FusedIterator for Iter<'a, K, V> {}
 
-impl<'a, K: EnumArray<V>, V> IntoIterator for &'a EnumMap<K, V> {
+impl<'a, K: Enum, V> IntoIterator for &'a EnumMap<K, V> {
     type Item = (K, &'a V);
     type IntoIter = Iter<'a, K, V>;
     #[inline]
@@ -127,7 +127,7 @@ pub struct IterMut<'a, K, V: 'a> {
     iterator: Enumerate<slice::IterMut<'a, V>>,
 }
 
-impl<'a, K: EnumArray<V>, V> Iterator for IterMut<'a, K, V> {
+impl<'a, K: Enum, V> Iterator for IterMut<'a, K, V> {
     type Item = (K, &'a mut V);
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -151,7 +151,7 @@ impl<'a, K: EnumArray<V>, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<'a, K: EnumArray<V>, V> DoubleEndedIterator for IterMut<'a, K, V> {
+impl<'a, K: Enum, V> DoubleEndedIterator for IterMut<'a, K, V> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iterator
@@ -160,11 +160,11 @@ impl<'a, K: EnumArray<V>, V> DoubleEndedIterator for IterMut<'a, K, V> {
     }
 }
 
-impl<'a, K: EnumArray<V>, V> ExactSizeIterator for IterMut<'a, K, V> {}
+impl<'a, K: Enum, V> ExactSizeIterator for IterMut<'a, K, V> {}
 
-impl<'a, K: EnumArray<V>, V> FusedIterator for IterMut<'a, K, V> {}
+impl<'a, K: Enum, V> FusedIterator for IterMut<'a, K, V> {}
 
-impl<'a, K: EnumArray<V>, V> IntoIterator for &'a mut EnumMap<K, V> {
+impl<'a, K: Enum, V> IntoIterator for &'a mut EnumMap<K, V> {
     type Item = (K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
     #[inline]
@@ -196,12 +196,12 @@ impl<'a, K: EnumArray<V>, V> IntoIterator for &'a mut EnumMap<K, V> {
 ///     assert_eq!(value + "4", "1234");
 /// }
 /// ```
-pub struct IntoIter<K: EnumArray<V>, V> {
+pub struct IntoIter<K: Enum, V> {
     map: ManuallyDrop<EnumMap<K, V>>,
     alive: Range<usize>,
 }
 
-impl<K: EnumArray<V>, V> Iterator for IntoIter<K, V> {
+impl<K: Enum, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
     fn next(&mut self) -> Option<(K, V)> {
         let position = self.alive.next()?;
@@ -216,7 +216,7 @@ impl<K: EnumArray<V>, V> Iterator for IntoIter<K, V> {
     }
 }
 
-impl<K: EnumArray<V>, V> DoubleEndedIterator for IntoIter<K, V> {
+impl<K: Enum, V> DoubleEndedIterator for IntoIter<K, V> {
     fn next_back(&mut self) -> Option<(K, V)> {
         let position = self.alive.next_back()?;
         Some((K::from_usize(position), unsafe {
@@ -225,11 +225,11 @@ impl<K: EnumArray<V>, V> DoubleEndedIterator for IntoIter<K, V> {
     }
 }
 
-impl<K: EnumArray<V>, V> ExactSizeIterator for IntoIter<K, V> {}
+impl<K: Enum, V> ExactSizeIterator for IntoIter<K, V> {}
 
-impl<K: EnumArray<V>, V> FusedIterator for IntoIter<K, V> {}
+impl<K: Enum, V> FusedIterator for IntoIter<K, V> {}
 
-impl<K: EnumArray<V>, V> Drop for IntoIter<K, V> {
+impl<K: Enum, V> Drop for IntoIter<K, V> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
@@ -238,7 +238,7 @@ impl<K: EnumArray<V>, V> Drop for IntoIter<K, V> {
     }
 }
 
-impl<K: EnumArray<V>, V> IntoIterator for EnumMap<K, V> {
+impl<K: Enum, V> IntoIterator for EnumMap<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
     #[inline]
@@ -251,7 +251,7 @@ impl<K: EnumArray<V>, V> IntoIterator for EnumMap<K, V> {
     }
 }
 
-impl<K: EnumArray<V>, V> EnumMap<K, V> {
+impl<K: Enum, V> EnumMap<K, V> {
     /// An iterator visiting all values. The iterator type is `&V`.
     ///
     /// # Examples
@@ -379,13 +379,13 @@ impl<'a, V: 'a> FusedIterator for ValuesMut<'a, V> {}
 ///
 /// This `struct` is created by the `into_values` method of `EnumMap`.
 /// See its documentation for more.
-pub struct IntoValues<K: EnumArray<V>, V> {
+pub struct IntoValues<K: Enum, V> {
     inner: IntoIter<K, V>,
 }
 
 impl<K, V> Iterator for IntoValues<K, V>
 where
-    K: EnumArray<V>,
+    K: Enum,
 {
     type Item = V;
 
@@ -398,12 +398,12 @@ where
     }
 }
 
-impl<K: EnumArray<V>, V> DoubleEndedIterator for IntoValues<K, V> {
+impl<K: Enum, V> DoubleEndedIterator for IntoValues<K, V> {
     fn next_back(&mut self) -> Option<V> {
         Some(self.inner.next_back()?.1)
     }
 }
 
-impl<K, V> ExactSizeIterator for IntoValues<K, V> where K: EnumArray<V> {}
+impl<K, V> ExactSizeIterator for IntoValues<K, V> where K: Enum {}
 
-impl<K, V> FusedIterator for IntoValues<K, V> where K: EnumArray<V> {}
+impl<K, V> FusedIterator for IntoValues<K, V> where K: Enum {}

--- a/enum-map/src/serde.rs
+++ b/enum-map/src/serde.rs
@@ -1,11 +1,11 @@
-use crate::{enum_map, EnumArray, EnumMap};
+use crate::{enum_map, Enum, EnumMap};
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 use serde::ser::{Serialize, SerializeMap, SerializeTuple, Serializer};
 
 /// Requires crate feature `"serde"`
-impl<K: EnumArray<V> + Serialize, V: Serialize> Serialize for EnumMap<K, V> {
+impl<K: Enum + Serialize, V: Serialize> Serialize for EnumMap<K, V> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
             serializer.collect_map(self)
@@ -22,7 +22,7 @@ impl<K: EnumArray<V> + Serialize, V: Serialize> Serialize for EnumMap<K, V> {
 /// Requires crate feature `"serde"`
 impl<'de, K, V> Deserialize<'de> for EnumMap<K, V>
 where
-    K: EnumArray<V> + EnumArray<Option<V>> + Deserialize<'de>,
+    K: Enum + Deserialize<'de>,
     V: Deserialize<'de>,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -38,7 +38,7 @@ struct HumanReadableVisitor<K, V>(PhantomData<(K, V)>);
 
 impl<'de, K, V> de::Visitor<'de> for HumanReadableVisitor<K, V>
 where
-    K: EnumArray<V> + EnumArray<Option<V>> + Deserialize<'de>,
+    K: Enum + Deserialize<'de>,
     V: Deserialize<'de>,
 {
     type Value = EnumMap<K, V>;
@@ -65,7 +65,7 @@ struct CompactVisitor<K, V>(PhantomData<(K, V)>);
 
 impl<'de, K, V> de::Visitor<'de> for CompactVisitor<K, V>
 where
-    K: EnumArray<V> + EnumArray<Option<V>> + Deserialize<'de>,
+    K: Enum + Deserialize<'de>,
     V: Deserialize<'de>,
 {
     type Value = EnumMap<K, V>;

--- a/enum-map/tests/test.rs
+++ b/enum-map/tests/test.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate enum_map;
 
-use enum_map::{Enum, EnumArray, EnumMap, IntoIter};
+use enum_map::{Enum, EnumMap, IntoIter};
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
@@ -437,6 +437,7 @@ enum X {
 
 impl Enum for X {
     const LENGTH: usize = 1;
+    type Array<V> = [V; Self::LENGTH];
 
     fn from_usize(arg: usize) -> X {
         assert_eq!(arg, 0);
@@ -446,10 +447,6 @@ impl Enum for X {
     fn into_usize(self) -> usize {
         0
     }
-}
-
-impl<V> EnumArray<V> for X {
-    type Array = [V; Self::LENGTH];
 }
 
 fn assert_sync_send<T: Sync + Send>(_: T) {}
@@ -563,6 +560,7 @@ macro_rules! make_enum_map_macro_safety_test {
 
         impl Enum for E {
             const LENGTH: usize = $a;
+            type Array<V> = [V; Self::LENGTH];
 
             fn from_usize(value: usize) -> E {
                 match value {
@@ -576,10 +574,6 @@ macro_rules! make_enum_map_macro_safety_test {
             fn into_usize(self) -> usize {
                 self as usize
             }
-        }
-
-        impl<V> EnumArray<V> for E {
-            type Array = [V; $b];
         }
 
         let map: EnumMap<E, String> = enum_map! { _ => "Hello, world!".into() };


### PR DESCRIPTION
I read in README that 

> library doesn't provide Minimum Supported Rust Version (MSRV).

If this means that we could use features from stable Rust, here's a PR that eliminates `EnumArray`, exploiting GADTs. This allows simpler trait bounds (simply `Enum` instead of `EnumArray<V>`), which may be valuable for users.