### PR TITLE
Add licenses for distribution packaging

### DIFF
--- a/enum-map-derive/LICENSE-APACHE
+++ b/enum-map-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/enum-map-derive/LICENSE-MIT
+++ b/enum-map-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/enum-map/LICENSE-APACHE
+++ b/enum-map/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/enum-map/LICENSE-MIT
+++ b/enum-map/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Symlink the license texts to the crate directories so `cargo package` would bundle them when packaging.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>