### PR TITLE
Ignore semver minor and patch updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
-    versioning-strategy: increase-if-necessary
+    ignore:
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
increase-if-necessary doesn't work.